### PR TITLE
Fix: Correct Telegram API credential access

### DIFF
--- a/utils/telegram.php
+++ b/utils/telegram.php
@@ -11,8 +11,8 @@ function sendTelegramMessage($message, $options = [])
 {
     global $config;
 
-    $chatId = $config['telegram']['chat_id'];
-    $botToken = $config['telegram']['bot_token'];
+    $chatId = $config['chat_id'];
+    $botToken = $config['bot_token'];
 
     $url = "https://api.telegram.org/bot{$botToken}/sendMessage";
 


### PR DESCRIPTION
The sendTelegramMessage function was attempting to access bot_token and chat_id from a nested 'telegram' key in the configuration array, whereas the configuration structure provides these at the top level.

This change corrects the array keys to `$config['bot_token']` and `$config['chat_id']` to ensure the Telegram API credentials are correctly loaded and used for sending messages.